### PR TITLE
update wrt to type-conv >= 108.07.00

### DIFF
--- a/syntax/.depend
+++ b/syntax/.depend
@@ -1,42 +1,42 @@
-base.cmo: utils.cmi type.cmi defs.cmi clusters.cmi base.cmi
-base.cmx: utils.cmx type.cmx defs.cmx clusters.cmx base.cmi
-base.cmi: type.cmi defs.cmi
-clusters.cmo: utils.cmi type.cmi clusters.cmi
-clusters.cmx: utils.cmx type.cmx clusters.cmi
-clusters.cmi: type.cmi
-defs.cmo: type.cmi defs.cmi
-defs.cmx: type.cmx defs.cmi
-defs.cmi: type.cmi
-extend.cmo: utils.cmi type.cmi id.cmo base.cmi extend.cmi
-extend.cmx: utils.cmx type.cmx id.cmx base.cmx extend.cmi
-extend.cmi:
-id.cmo:
-id.cmx:
-pa_deriving.cmo:
-pa_deriving.cmx:
-pa_deriving_tc.cmo: type.cmi defs.cmi base.cmi
-pa_deriving_tc.cmx: type.cmx defs.cmx base.cmx
-type.cmo: utils.cmi type.cmi
-type.cmx: utils.cmx type.cmi
-type.cmi: utils.cmi
-utils.cmo: utils.cmi
-utils.cmx: utils.cmi
-utils.cmi:
-classes/bounded_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/bounded_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/dump_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/dump_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/enum_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/enum_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/eq_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/eq_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/functor_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/functor_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/pickle_class.cmo: utils.cmi classes/typeable_class.cmo type.cmi \
+base.cmo : utils.cmi type.cmi defs.cmi clusters.cmi base.cmi
+base.cmx : utils.cmx type.cmx defs.cmx clusters.cmx base.cmi
+base.cmi : type.cmi defs.cmi
+clusters.cmo : utils.cmi type.cmi clusters.cmi
+clusters.cmx : utils.cmx type.cmx clusters.cmi
+clusters.cmi : type.cmi
+defs.cmo : type.cmi defs.cmi
+defs.cmx : type.cmx defs.cmi
+defs.cmi : type.cmi
+extend.cmo : utils.cmi type.cmi id.cmo base.cmi extend.cmi
+extend.cmx : utils.cmx type.cmx id.cmx base.cmx extend.cmi
+extend.cmi :
+id.cmo :
+id.cmx :
+pa_deriving.cmo :
+pa_deriving.cmx :
+pa_deriving_tc.cmo : type.cmi defs.cmi base.cmi
+pa_deriving_tc.cmx : type.cmx defs.cmx base.cmx
+type.cmo : utils.cmi type.cmi
+type.cmx : utils.cmx type.cmi
+type.cmi : utils.cmi
+utils.cmo : utils.cmi
+utils.cmx : utils.cmi
+utils.cmi :
+classes/bounded_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/bounded_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/dump_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/dump_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/enum_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/enum_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/eq_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/eq_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/functor_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/functor_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/pickle_class.cmo : utils.cmi classes/typeable_class.cmo type.cmi \
     classes/eq_class.cmo defs.cmi base.cmi
-classes/pickle_class.cmx: utils.cmx classes/typeable_class.cmx type.cmx \
+classes/pickle_class.cmx : utils.cmx classes/typeable_class.cmx type.cmx \
     classes/eq_class.cmx defs.cmx base.cmx
-classes/show_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/show_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
-classes/typeable_class.cmo: utils.cmi type.cmi defs.cmi base.cmi
-classes/typeable_class.cmx: utils.cmx type.cmx defs.cmx base.cmx
+classes/show_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/show_class.cmx : utils.cmx type.cmx defs.cmx base.cmx
+classes/typeable_class.cmo : utils.cmi type.cmi defs.cmi base.cmi
+classes/typeable_class.cmx : utils.cmx type.cmx defs.cmx base.cmx

--- a/syntax/pa_deriving_tc.ml
+++ b/syntax/pa_deriving_tc.ml
@@ -9,12 +9,12 @@ open Camlp4.PreCast
 
 open Pa_deriving_common
 
-let translate_str deriver types =
+let translate_str deriver _ types =
   let _loc = Ast.loc_of_ctyp types in
   let decls = Base.display_errors _loc Type.Translate.decls types in
   Base.derive_str _loc decls deriver
 
-let translate_sig deriver types =
+let translate_sig deriver _ types =
   let _loc = Ast.loc_of_ctyp types in
   let decls = Base.display_errors _loc Type.Translate.decls types in
   Base.derive_sig _loc decls deriver


### PR DESCRIPTION
opam file for version 0.3c has to be updated with

```
depopts: [
  "type_conv" {< "108.07.00"}
]
```

next versions should contain

```
depopts: [
  "type_conv" {>= "108.07.00"}
]

```
