### PR TITLE
Handle private row types in some particular case

### DIFF
--- a/syntax/base.ml
+++ b/syntax/base.ml
@@ -400,7 +400,7 @@ module InnerGenerator(Loc: Loc)(Desc : InnerClassDescription) = struct
         | `Fresh (eq, Record fields, _) ->
 	    self#wrap ctxt ty (self#record ?eq ctxt tname params constraints fields)
         | `Expr e -> self#expr ctxt e
-        | `Variant v ->
+        | `Variant (v,p) ->
 	    self#wrap ctxt ty (self#variant ctxt tname params constraints v)
         | `Nothing -> <:module_expr< >>
 

--- a/syntax/classes/functor_class.ml
+++ b/syntax/classes/functor_class.ml
@@ -158,7 +158,7 @@ module Builder(Generator : Defs.Generator) = struct
        <:expr< fun $Helpers.record_pattern fields$ ->
                    $Helpers.record_expr (List.map (fun ((l,_,_) as f) -> (l,field context f)) fields)$ >>
     |`Expr e                  -> expr context e
-    |`Variant (_, tags) ->
+    |`Variant ((_, tags), _) ->
        <:expr< function $list:List.map (polycase context) tags$ | _ -> assert false >>
     | `Nothing -> raise (Base.Underivable "Cannot generate functor instance for the empty type")
 

--- a/syntax/type.mli
+++ b/syntax/type.mli
@@ -25,7 +25,7 @@ and rhs =
     [ `Expr of expr
     | `Fresh of expr option * repr * [ `Private | `Public ]
     | `Nothing
-    | `Variant of variant ]
+    | `Variant of variant * [ `Private | `Public ] ]
 
 and repr = Sum of summand list  | GSum of name * gsummand list | Record of field list
 


### PR DESCRIPTION
This allows to handle private row types in the particular case of:

``` ocaml
module type A = sig
  type t = private [> `A ]
      deriving (Show)
end

module Make(M : A) = struct
  type truc = Plop of M.t
        deriving (Show)

  let chose x = Plop x
end

module MA = struct
  type t = [ `A | `B ]
      deriving (Show)
end

module M = Make(MA)

let _ = print_endline (Show.show<M.truc>(M.chose `B))
```
