### PR TITLE
OCaml 4.06.0 compatibility fix

### DIFF
--- a/lib/deriving_Dump.ml
+++ b/lib/deriving_Dump.ml
@@ -142,7 +142,7 @@ module Dump_string = Defaults (
         for i = 0 to len - 1 do
           Bytes.unsafe_set s i (Stream.next stream)
         done;
-        s
+        Bytes.to_string s
   end
 )
 
@@ -241,7 +241,8 @@ module Dump_via_marshal (P : sig type a end) = Defaults (
   struct
     include P
     let to_buffer buffer obj = Buffer.add_string buffer (Marshal.to_string obj [Marshal.Closures])
-    let from_stream stream = 
+    let from_stream stream =
+      let to_string bs = Bytes.to_string bs in
       let readn n = 
         let s = Bytes.create n in
         for i = 0 to n - 1 do
@@ -252,5 +253,5 @@ module Dump_via_marshal (P : sig type a end) = Defaults (
       let header = readn Marshal.header_size in
       let datasize = Marshal.data_size header 0 in
       let datapart = readn datasize in
-        Marshal.from_string (header ^ datapart) 0
+        Marshal.from_string ((to_string header) ^ (to_string datapart)) 0
   end)

--- a/lib/deriving_Dump.ml
+++ b/lib/deriving_Dump.ml
@@ -226,8 +226,8 @@ module Dump_alpha(P: sig type a end) = Defaults(struct
   let from_stream _ = assert false
 end)
 
-module Dump_undumpable (P : sig type a val tname : string end) = Defaults ( 
-  struct 
+module Dump_undumpable (P : sig type a val tname : string end) = Defaults (
+  struct
     type a = P.a
     let to_buffer _ _ = failwith ("Dump: attempt to serialise a value of unserialisable type : " ^ P.tname)
     let from_stream _ = failwith ("Dump: attempt to deserialise a value of unserialisable type : " ^ P.tname)
@@ -242,8 +242,7 @@ module Dump_via_marshal (P : sig type a end) = Defaults (
     include P
     let to_buffer buffer obj = Buffer.add_string buffer (Marshal.to_string obj [Marshal.Closures])
     let from_stream stream =
-      let to_string bs = Bytes.to_string bs in
-      let readn n = 
+      let readn n =
         let s = Bytes.create n in
         for i = 0 to n - 1 do
           Bytes.set s i (Stream.next stream)
@@ -253,5 +252,5 @@ module Dump_via_marshal (P : sig type a end) = Defaults (
       let header = readn Marshal.header_size in
       let datasize = Marshal.data_size header 0 in
       let datapart = readn datasize in
-        Marshal.from_string ((to_string header) ^ (to_string datapart)) 0
+        Marshal.from_bytes (Bytes.cat header datapart) 0
   end)

--- a/lib/deriving_interned.ml
+++ b/lib/deriving_interned.ml
@@ -14,15 +14,16 @@ type t = int * string
     deriving (Show)
 
 let intern s =
-  try BytesMap.find s !map
+  let bs = Bytes.of_string s in
+  try BytesMap.find bs !map
   with Not_found ->
-    let fresh = (!counter, Bytes.of_string s) in begin
-      map := BytesMap.add s fresh !map;
+    let fresh = (!counter, s) in begin
+      map := BytesMap.add bs fresh !map;
       incr counter;
       fresh
     end
 
-let to_string (_,s) = Bytes.to_string s
+let to_string (_,s) = s
 let name = snd
 let compare (l,_) (r,_) = compare l r
 let eq (l,_) (r,_) = l = r

--- a/syntax/common/utils.ml
+++ b/syntax/common/utils.ml
@@ -216,7 +216,7 @@ let random_id length =
     for i = 0 to length - 1 do
       Bytes.set s i idchars.[Random.int nidchars]
     done;
-    s
+    Bytes.to_string s
 
 (* The function used in OCaml to convert variant labels to their
    integer representations.  The formula is given in Jacques


### PR DESCRIPTION
OCaml 4.06.0 toggles `-safe-string` by default, thereby causing `bytes` and `string` to be distinct types. This patch fixes some inconsistent uses of strings and bytes.