### PR TITLE
-safe-string fix for OCaml 4.06.0

### DIFF
--- a/lib/deriving_Dump.ml
+++ b/lib/deriving_Dump.ml
@@ -136,13 +136,13 @@ module Dump_string = Defaults (
         Dump_int.to_buffer buffer (String.length string);
         Buffer.add_string buffer string
       end
-    and from_stream stream = 
+    and from_stream stream =
       let len = Dump_int.from_stream stream in
       let s = Bytes.create len in
         for i = 0 to len - 1 do
           Bytes.unsafe_set s i (Stream.next stream)
         done;
-        s
+        Bytes.to_string s
   end
 )
 
@@ -252,5 +252,5 @@ module Dump_via_marshal (P : sig type a end) = Defaults (
       let header = readn Marshal.header_size in
       let datasize = Marshal.data_size header 0 in
       let datapart = readn datasize in
-        Marshal.from_string (header ^ datapart) 0
+        Marshal.from_string (Bytes.to_string header ^ Bytes.to_string datapart) 0
   end)

--- a/lib/deriving_interned.ml
+++ b/lib/deriving_interned.ml
@@ -4,25 +4,25 @@
 *)
 
 (* Interned strings *)
-module BytesMap = Map.Make(Bytes)
+module StringMap = Map.Make(String)
 
 (* global state *)
-let map = ref BytesMap.empty
+let map = ref StringMap.empty
 let counter = ref 0
 
 type t = int * string
     deriving (Show)
 
 let intern s =
-  try BytesMap.find s !map
+  try StringMap.find s !map
   with Not_found ->
-    let fresh = (!counter, Bytes.of_string s) in begin
-      map := BytesMap.add s fresh !map;
+    let fresh = (!counter, s) in begin
+      map := StringMap.add s fresh !map;
       incr counter;
       fresh
     end
 
-let to_string (_,s) = Bytes.to_string s
+let to_string (_,s) = s
 let name = snd
 let compare (l,_) (r,_) = compare l r
 let eq (l,_) (r,_) = l = r

--- a/opam
+++ b/opam
@@ -18,6 +18,7 @@ depends: [
   "ocamlfind"
   "camlp4"
   "optcomp"
+  "base-bytes"
   ## OASIS is not required in released version
   "oasis" {>= "0.4.4"}
 ]

--- a/syntax/common/utils.ml
+++ b/syntax/common/utils.ml
@@ -216,7 +216,7 @@ let random_id length =
     for i = 0 to length - 1 do
       Bytes.set s i idchars.[Random.int nidchars]
     done;
-    s
+    Bytes.to_string s
 
 (* The function used in OCaml to convert variant labels to their
    integer representations.  The formula is given in Jacques


### PR DESCRIPTION
`Deriving_interned.intern` was inconsistent about its parameter's type, so it was easier to use a `StringMap`.